### PR TITLE
Add -O2 flag to Pythia compilation

### DIFF
--- a/HEPToolInstaller.py
+++ b/HEPToolInstaller.py
@@ -1132,7 +1132,7 @@ def install_pythia8(tmp_path):
         except:
             pass
         pass
-    cxx_common = ['-ldl','-fPIC',_cpp_standard_lib, '-std=c++11']
+    cxx_common = ['-O2', '-ldl','-fPIC',_cpp_standard_lib, '-std=c++11']
     if hepmc_named_weight_support:
         cxx_common.append('-DHEPMC2HACK')
         logger.debug("The version of HepMC supports the writing of named weights: %s ", _HepTools['hepmc']['install_path'])


### PR DESCRIPTION
Hi,

I added the `-O2` flag to `CXX_COMMON` flags used during Pythia installation.

I found out that the Pythia compilation through `install pythia8` does not contain the flag `-O2`.
This happens because MadGraph sets the `CXX_COMMON` flags while compiling Pythia and does not use the default ones (which contain the `-O2` flag).
I verified that compiling Pythia with this optimization results in a substantial improvement of speed (at least in my case), see [this issue raised in the MadDM launchpad page](https://bugs.launchpad.net/maddm/+bug/2000771).

--
Daniele